### PR TITLE
fix gradle deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects { project ->
     task codeCoverageReport(type: JacocoReport) {
         reports {
             xml.enabled true
-            xml.destination "${buildDir}/reports/jacoco/report.xml"
+            xml.destination file("${buildDir}/reports/jacoco/report.xml")
             html.enabled true
             csv.enabled false
         }

--- a/kategory-docs/build.gradle
+++ b/kategory-docs/build.gradle
@@ -16,8 +16,10 @@ dependencies {
     compile "io.reactivex.rxjava2:rxjava:2.1.4"
 }
 
-task printcp << {
-    println sourceSets.main.runtimeClasspath.each { println it }
+task printcp {
+    doLast {
+        println sourceSets.main.runtimeClasspath.each { println it }
+    }
 }
 
 ank {


### PR DESCRIPTION
 - The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.
   The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.